### PR TITLE
New option to set cache dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+SOURCEDIR=.
+SOURCES := $(shell find $(SOURCEDIR) -name '*.go')
+BINARY=vaultflow
+BIN_DIR=bin
+BINFILE=${BIN_DIR}/${BINARY}
+
+.PHONY: clean
+
+$(BINARY): $(BINFILE)
+
+$(BINFILE): $(SOURCES)
+	go build -o ${BINFILE} main.go
+
+clean:
+	rm -v $(BINFILE)
+
+lint: $(SOURCES)
+	golint -set_exit_status $?
+
+docker:
+	docker build . -t alaa/vaultflow:latest

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Proposal workflow for managing secrets across a team.
 - Add YAML file configrations
 - Add local encryption options
 
+# build
+    make clean
+    make
+
+# build docker container
+    make docker
+
 # Misc
 ```docker run -it -p8500:8500 progrium/consul -server -bootstrap-expect 1```
 

--- a/scripts/build
+++ b/scripts/build
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-docker build . -t alaa/vaultflow:latest

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -95,8 +95,10 @@ func (s *Sync) Pull(force bool) error {
 		}
 
 		if err = s.cache.Put(key, json); err != nil {
-			return errors.New(fmt.Sprintf("Could not write secret to the cache: %s", err))
+			return fmt.Errorf("Could not write secret to the cache: %s", err)
 		}
+
+		log.Printf("Got secret for %s\n", key)
 	}
 
 	if err = s.cache.UpdateRevision(revisions["remote"]); err != nil {

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -73,7 +73,7 @@ func (v *Vault) GetSecrets() (Secrets, error) {
 	secrets := make(Secrets)
 	keys, err := v.ListSecrets("/secret")
 	if err != nil {
-		return Secrets{}, nil
+		return Secrets{}, err;
 	}
 
 	for _, key := range keys {


### PR DESCRIPTION
Strip cache dirname from --secret option.
This allow the user to use --secret=vault-data/secret_name, which
allows the usage of bash completion for secret names

Added Makefile

Fixed bug when vault returns an error.

Changed default cache dir to a non-hidden directory